### PR TITLE
PATCH change 1.3.0 -> 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fe",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "private": true,
     "dependencies": {
         "@material-ui/core": "^4.9.7",

--- a/src/components/ui/Backdrop.js
+++ b/src/components/ui/Backdrop.js
@@ -4,7 +4,9 @@ import { toggleModal } from '../../redux/actionCreators';
 
 const Backdrop = ({ modalName, toggleModal, authLoading, propertyLoading }) => {
     const clickHandler = () => {
-        return authLoading || propertyLoading ? null : toggleModal(modalName);
+        return authLoading || propertyLoading || !modalName
+            ? null
+            : toggleModal(modalName);
     };
 
     return <div className="backdrop" onClick={clickHandler}></div>;


### PR DESCRIPTION
## Change log

### Bug fix:
* removed Backdrop component's ability to error out when a modalName isn't specified, (i.e. during a load screen being present and clicking backdrop)